### PR TITLE
Add niceAgentIceTcp configuration option and API methods for it

### DIFF
--- a/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.c
@@ -254,6 +254,17 @@ kms_webrtc_base_connection_set_network_ifs_info (KmsWebRtcBaseConnection *
 }
 
 void
+kms_webrtc_base_connection_set_agent_ice_tcp (KmsWebRtcBaseConnection *
+    self, gboolean niceAgentIceTcp)
+{
+  if (KMS_IS_ICE_NICE_AGENT (self->agent)) {
+    KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self->agent);
+    g_object_set (kms_ice_nice_agent_get_agent (nice_agent),
+        "ice-tcp", niceAgentIceTcp, NULL);
+  }
+}
+
+void
 kms_webrtc_base_connection_set_stun_server_info (KmsWebRtcBaseConnection * self,
     const gchar * ip, guint port)
 {

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcbaseconnection.h
@@ -81,6 +81,8 @@ gchar *kms_webrtc_base_connection_get_certificate_pem (KmsWebRtcBaseConnection *
     self);
 void kms_webrtc_base_connection_set_network_ifs_info (KmsWebRtcBaseConnection *
     self, const gchar * net_names);
+void kms_webrtc_base_connection_set_agent_ice_tcp (KmsWebRtcBaseConnection *
+    self, gboolean niceAgenIceTcp);
 void kms_webrtc_base_connection_set_stun_server_info (KmsWebRtcBaseConnection * self,
     const gchar * stun_server_ip, guint stun_server_port);
 void kms_webrtc_base_connection_set_relay_info (KmsWebRtcBaseConnection * self,

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsession.c
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsession.c
@@ -56,6 +56,7 @@ G_DEFINE_TYPE (KmsWebrtcSession, kms_webrtc_session, KMS_TYPE_BASE_RTP_SESSION);
 #define DEFAULT_PEM_CERTIFICATE NULL
 #define DEFAULT_NETWORK_INTERFACES NULL
 #define DEFAULT_EXTERNAL_ADDRESS NULL
+#define DEFAULT_NICEAGENT_ICE_TCP TRUE
 
 #define IP_VERSION_6 6
 
@@ -90,6 +91,7 @@ enum
   PROP_PEM_CERTIFICATE,
   PROP_NETWORK_INTERFACES,
   PROP_EXTERNAL_ADDRESS,
+  PROP_NICEAGENT_ICE_TCP,
   N_PROPERTIES
 };
 
@@ -793,6 +795,14 @@ kms_webrtc_session_set_network_ifs_info (KmsWebrtcSession * self,
 }
 
 static void
+kms_webrtc_session_set_niceagent_ice_tcp (KmsWebrtcSession * self,
+    KmsWebRtcBaseConnection * conn)
+{
+  kms_webrtc_base_connection_set_agent_ice_tcp (conn, self->niceagent_ice_tcp);
+}
+
+
+static void
 kms_webrtc_session_set_stun_server_info (KmsWebrtcSession * self,
     KmsWebRtcBaseConnection * conn)
 {
@@ -831,6 +841,7 @@ kms_webrtc_session_gather_candidates (KmsWebrtcSession * self)
     KmsWebRtcBaseConnection *conn = KMS_WEBRTC_BASE_CONNECTION (v);
 
     kms_webrtc_session_set_network_ifs_info (self, conn);
+    kms_webrtc_session_set_niceagent_ice_tcp (self, conn);
     kms_webrtc_session_set_stun_server_info (self, conn);
     kms_webrtc_session_set_relay_info (self, conn);
 
@@ -1726,6 +1737,9 @@ kms_webrtc_session_set_property (GObject * object, guint prop_id,
       g_free (self->external_address);
       self->external_address = g_value_dup_string (value);
       break;
+    case PROP_NICEAGENT_ICE_TCP:
+      self->niceagent_ice_tcp = g_value_get_boolean (value);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -1763,6 +1777,9 @@ kms_webrtc_session_get_property (GObject * object, guint prop_id,
       break;
     case PROP_EXTERNAL_ADDRESS:
       g_value_set_string (value, self->external_address);
+      break;
+    case PROP_NICEAGENT_ICE_TCP:
+      g_value_set_boolean (value, self->niceagent_ice_tcp);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -1900,6 +1917,7 @@ kms_webrtc_session_init (KmsWebrtcSession * self)
   self->pem_certificate = DEFAULT_PEM_CERTIFICATE;
   self->network_interfaces = DEFAULT_NETWORK_INTERFACES;
   self->external_address = DEFAULT_EXTERNAL_ADDRESS;
+  self->niceagent_ice_tcp = DEFAULT_NICEAGENT_ICE_TCP;
   self->gather_started = FALSE;
 
   self->data_channels = g_hash_table_new_full (g_direct_hash,
@@ -2004,6 +2022,12 @@ kms_webrtc_session_class_init (KmsWebrtcSessionClass * klass)
           "externalAddress",
           "External (public) IP address of the media server",
           DEFAULT_EXTERNAL_ADDRESS, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_NICEAGENT_ICE_TCP,
+      g_param_spec_boolean ("niceagent-ice-tcp",
+          "niceAgentIceTcp",
+          "Enable NiceAgent's ICE-TCP gathering",
+          DEFAULT_NICEAGENT_ICE_TCP, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_DATA_CHANNEL_SUPPORTED,
       g_param_spec_boolean ("data-channel-supported",

--- a/src/gst-plugins/webrtcendpoint/kmswebrtcsession.h
+++ b/src/gst-plugins/webrtcendpoint/kmswebrtcsession.h
@@ -72,6 +72,7 @@ struct _KmsWebrtcSession
   gchar *pem_certificate;
   gchar *network_interfaces;
   gchar *external_address;
+  gboolean niceagent_ice_tcp;
 
   guint16 min_port;
   guint16 max_port;

--- a/src/server/config/WebRtcEndpoint.conf.ini
+++ b/src/server/config/WebRtcEndpoint.conf.ini
@@ -102,3 +102,13 @@
 ;; externalAddress=2001:0db8:85a3:0000:0000:8a2e:0370:7334
 ;;
 ;externalAddress=10.20.30.40
+
+;; Whether to enable TCP candidate gathering via NiceAgent's ice-tcp property.
+;; The motivation behind this is to potentially speed up gathering
+;; by preventing TCP candidate gathering in scenarios where they aren't needed.
+;; Property reference: https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--ice-tcp
+;;
+;; <niceAgentIceTcp> MUST be either 0 (FALSE) or 1 (TRUE)
+;; Default is 1 (TRUE)
+;;
+;niceAgentIceTcp=1

--- a/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -54,9 +54,11 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 
 #define PARAM_EXTERNAL_ADDRESS "externalAddress"
 #define PARAM_NETWORK_INTERFACES "networkInterfaces"
+#define PARAM_NICEAGENT_ICE_TCP "niceAgentIceTcp"
 
 #define PROP_EXTERNAL_ADDRESS "external-address"
 #define PROP_NETWORK_INTERFACES "network-interfaces"
+#define PROP_NICEAGENT_ICE_TCP "niceagent-ice-tcp"
 
 namespace kurento
 {
@@ -532,6 +534,17 @@ WebRtcEndpointImpl::WebRtcEndpointImpl (const boost::property_tree::ptree &conf,
                " you can set one or default to ICE automatic discovery");
   }
 
+  gboolean niceAgentIceTcp;
+  if (getConfigValue <gboolean, WebRtcEndpoint> (&niceAgentIceTcp,
+      PARAM_NICEAGENT_ICE_TCP)) {
+    GST_INFO ("NiceAgent ice-tcp set to %d", niceAgentIceTcp);
+    g_object_set (G_OBJECT (element), PROP_NICEAGENT_ICE_TCP,
+        niceAgentIceTcp, NULL);
+  } else {
+    GST_DEBUG ("NiceAgent ice-tcp option not found in config;"
+               " you can set one or default to ice-tcp 1 - TRUE");
+  }
+
   uint stunPort = 0;
 
   if (!getConfigValue <uint, WebRtcEndpoint> (&stunPort, "stunServerPort",
@@ -670,6 +683,23 @@ WebRtcEndpointImpl::setNetworkInterfaces (const std::string &networkInterfaces)
   GST_INFO ("Set network interfaces: %s", networkInterfaces.c_str());
   g_object_set (G_OBJECT (element), PROP_NETWORK_INTERFACES,
       networkInterfaces.c_str(), NULL);
+}
+
+bool
+WebRtcEndpointImpl::getNiceAgentIceTcp ()
+{
+  bool ret;
+
+  g_object_get ( G_OBJECT (element), "niceagent-ice-tcp", &ret, NULL);
+
+  return ret;
+}
+
+void
+WebRtcEndpointImpl::setNiceAgentIceTcp (bool niceAgentIceTcp)
+{
+  g_object_set ( G_OBJECT (element), "niceagent-ice-tcp",
+                 niceAgentIceTcp, NULL);
 }
 
 std::string

--- a/src/server/implementation/objects/WebRtcEndpointImpl.hpp
+++ b/src/server/implementation/objects/WebRtcEndpointImpl.hpp
@@ -52,6 +52,9 @@ public:
   std::string getNetworkInterfaces () override;
   void setNetworkInterfaces (const std::string &networkInterfaces) override;
 
+  bool getNiceAgentIceTcp () override;
+  void setNiceAgentIceTcp (bool niceAgentIceTcp) override;
+
   std::string getStunServerAddress () override;
   void setStunServerAddress (const std::string &stunServerAddress) override;
 

--- a/src/server/interface/elements.WebRtcEndpoint.kmd.json
+++ b/src/server/interface/elements.WebRtcEndpoint.kmd.json
@@ -305,6 +305,11 @@
           "type": "String"
         },
         {
+          "name": "niceAgentIceTcp",
+          "doc": "Enable libnice agent's ice-tcp option",
+          "type": "boolean"
+        },
+        {
           "name": "stunServerAddress",
           "doc": "STUN server IP address.
 <p>The ICE process uses STUN to punch holes through NAT firewalls.</p>


### PR DESCRIPTION
This adds the ability to configure libnice`s NiceAgent ice-tcp property through WebRtcEndpoint.conf.ini or via API

The rationale behind this is to give the ability to deactivate TCP candidate gathering in setups where they aren`t needed, thus potentially speeding up the gathering process and connectivity checks

Property reference: https://libnice.freedesktop.org/libnice/NiceAgent.html#NiceAgent--ice-tcp